### PR TITLE
JIR-10677 Fixed remote tools not opening for android 13 tablets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.darktalker.cordova.screenshot",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "screenshot PhoneGap Plugin for Android",
   "cordova": {
     "id": "com.darktalker.cordova.screenshot",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin id="com.darktalker.cordova.screenshot" version="0.1.6" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.darktalker.cordova.screenshot" version="0.1.7" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>com.darktalker.cordova.screenshot</name>
     <description>screenshot PhoneGap Plugin for Android</description>
     <license>MIT</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,7 +19,7 @@
             </feature>
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29"/>
+            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
         </config-file>
         <source-file src="src/android/Screenshot.java" target-dir="src/com/darktalker/cordova/screenshot"/>
         <source-file src="src/android/PermissionHelper.java" target-dir="src/com/darktalker/cordova/screenshot"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,7 +19,7 @@
             </feature>
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29"/>
         </config-file>
         <source-file src="src/android/Screenshot.java" target-dir="src/com/darktalker/cordova/screenshot"/>
         <source-file src="src/android/PermissionHelper.java" target-dir="src/com/darktalker/cordova/screenshot"/>

--- a/src/android/Screenshot.java
+++ b/src/android/Screenshot.java
@@ -14,6 +14,7 @@ import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.CompressFormat;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Environment;
 import android.util.Base64;
 import android.view.TextureView;
@@ -221,7 +222,7 @@ public class Screenshot extends CordovaPlugin {
         mArgs = args;
 
         if (action.equals("saveScreenshot")) {
-            if(PermissionHelper.hasPermission(this, PERMISSIONS[0])) {
+            if(Build.VERSION.SDK_INT >= 30 || PermissionHelper.hasPermission(this, PERMISSIONS[0])) { // WRITE_EXTERNAL_STORAGE is deprecated from 33 and does not have impact since 30+ SDK
                 saveScreenshot();
             } else {
                 PermissionHelper.requestPermissions(this, SAVE_SCREENSHOT_SEC, PERMISSIONS);


### PR DESCRIPTION
Fixed JIR-10677 where we were facing issues when remote viewing on android 13 tablets. We have forked our version and made changes for permissions. Now remote tools are opening properly. We have validated android 13, 11 and 10 tablet versions. 